### PR TITLE
Error handler is configured only when ErrorHandlingPath is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ Please use the following snippet to configure service which use Razon Pages only
 
         protected override IEnumerable<IMicroserviceInitializer> CreateInitializers()
         {
-            yield return new DeveloperExceptionPageInitializer(Configuration);
+            yield return new DeveloperExceptionPageInitializer(Configuration)
+            {
+                ErrorHandlingPath = "/Error"
+            };
+
             yield return new HttpsInitializer(Configuration);
 
             yield return new GenericInitializer((app, env) => app.UseStaticFiles());
@@ -99,7 +103,11 @@ Please use the following snippet to configure service which use ASP.NET MVC only
 
         protected override IEnumerable<IMicroserviceInitializer> CreateInitializers()
         {
-            yield return new DeveloperExceptionPageInitializer(Configuration);
+            yield return new DeveloperExceptionPageInitializer(Configuration)
+            {
+                ErrorHandlingPath = "/Error"
+            };
+
             yield return new HttpsInitializer(Configuration);
 
             yield return new GenericInitializer((app, env) => app.UseStaticFiles());
@@ -127,7 +135,11 @@ The following snippet is example of microservice using Razor Pages and REST APIs
 
         protected override IEnumerable<IMicroserviceInitializer> CreateInitializers()
         {
-            yield return new DeveloperExceptionPageInitializer(Configuration);
+            yield return new DeveloperExceptionPageInitializer(Configuration)
+            {
+                ErrorHandlingPath = "/Error"
+            };
+                        
             yield return new HttpsInitializer(Configuration);
 
             yield return new GenericInitializer((app, env) => app.UseStaticFiles());

--- a/src/GodelTech.Microservices.Core/GodelTech.Microservices.Core.csproj
+++ b/src/GodelTech.Microservices.Core/GodelTech.Microservices.Core.csproj
@@ -10,7 +10,7 @@
     <Authors>Andrei Salanoi</Authors>
     <RepositoryUrl>https://github.com/GodelTech/GodelTech.Microservices.Core</RepositoryUrl>
     <PackageIconUrl>https://www.gravatar.com/avatar/839234621070de51e7b9cabd5ceee8fe?s=64</PackageIconUrl>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
 
     <!-- SonarQube needs this -->
     <ProjectGuid>{00000000-0000-0000-0000-000000000001}</ProjectGuid>

--- a/src/GodelTech.Microservices.Core/Mvc/DeveloperExceptionPageInitializer.cs
+++ b/src/GodelTech.Microservices.Core/Mvc/DeveloperExceptionPageInitializer.cs
@@ -8,7 +8,11 @@ namespace GodelTech.Microservices.Core.Mvc
 {
     public class DeveloperExceptionPageInitializer : MicroserviceInitializerBase
     {
-        public string ErrorHandlingPath { get; set; } = "/Error";
+        /// <summary>
+        /// This option makes sense for UI application. REST API application should return
+        /// HTTP status error code rather than render HTML page containing error information.
+        /// </summary>
+        public string ErrorHandlingPath { get; set; }
 
         public DeveloperExceptionPageInitializer(IConfiguration configuration) 
             : base(configuration)
@@ -28,7 +32,8 @@ namespace GodelTech.Microservices.Core.Mvc
             }
             else
             {
-                app.UseExceptionHandler(ErrorHandlingPath);
+                if (!string.IsNullOrWhiteSpace(ErrorHandlingPath))
+                    app.UseExceptionHandler(ErrorHandlingPath);
             }
         }
     }


### PR DESCRIPTION
REST API configuration doesn't require error page is production. HTTP Status code is expected. REST API is going to be more frequent case of framework usage rather than UI. This was the reason to NOT configure error handler by default.